### PR TITLE
fix for broken history navigation

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -59,7 +59,7 @@ export default function syncHistoryWithStore(history, store, {
       currentLocation = locationInStore
       history.transitionTo({
         ...locationInStore,
-        action: 'PUSH'
+        action: 'REPLACE'
       })
       isTimeTraveling = false
     }


### PR DESCRIPTION
when using middle ware that intercepts location change actions navigating back in browser history loops you on two last states without this fix